### PR TITLE
fix default ttl (Input should be greater than or equal to 60)

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -134,6 +134,9 @@ func mapRecordsToLibds(zone string, records []Record) []libdns.Record {
 func libdnsToRecord(zone string, libdnsRecord libdns.Record) Record {
     // for TTL
     ttl := libdnsRecord.TTL.Seconds()
+    if ttl == 0 {
+        ttl = 60
+    }
 
     // for Value
 	recVals := strings.Split(libdnsRecord.Value, "\n")


### PR DESCRIPTION
```{"error":"bad_request","description":"Input should be greater than or equal to 60","location":"body.ttl"}```